### PR TITLE
feat: Add variable name to HTTP request nodes

### DIFF
--- a/src/components/custom/http-trigger-dialog.tsx
+++ b/src/components/custom/http-trigger-dialog.tsx
@@ -23,6 +23,13 @@ import {
 import { Textarea } from "../ui/textarea";
 
 const formSchema = z.object({
+  variableName: z
+    .string()
+    .min(1, { message: "Variable name must be at least 1 character long" })
+    .regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/, {
+      message:
+        "Variable name must start with a letter or underscore and can only contain letters, numbers, and underscores",
+    }),
   endpoint: z.url({ message: "Please enter a valid URL" }),
   method: z.enum(["GET", "POST", "PUT", "DELETE"]),
   body: z.string().optional(),
@@ -46,6 +53,7 @@ export const HttpTriggerDialog = ({
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
+      variableName: defaultValues.variableName || "",
       endpoint: defaultValues.endpoint || "",
       method: defaultValues.method || "GET",
       body: defaultValues.body || "",
@@ -56,6 +64,7 @@ export const HttpTriggerDialog = ({
   useEffect(() => {
     if (open) {
       form.reset({
+        variableName: defaultValues.variableName || "",
         endpoint: defaultValues.endpoint || "",
         method: defaultValues.method || "GET",
         body: defaultValues.body || "",
@@ -63,6 +72,7 @@ export const HttpTriggerDialog = ({
     }
   }, [open, defaultValues, form]);
 
+  const watchVariableName = form.watch("variableName") || "myApiCall";
   const showBodyField = form.watch("method") === "POST";
   const bodyPlaceholder = `{
     "userId": "{{httpResponse.data.id}}",
@@ -81,6 +91,22 @@ export const HttpTriggerDialog = ({
         </DialogHeader>
         <form className="space-y-8 mt-5" onSubmit={form.handleSubmit(onSubmit)}>
           <FieldGroup>
+            <Controller
+              name="variableName"
+              control={form.control}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor="variableName">Variable Name</FieldLabel>
+                  <Input id="variableName" placeholder="myApiCall" {...field} />
+                  <FieldDescription>
+                    Use this name to reference the response data in other nodes of your
+                    workflow. {`{{${watchVariableName}.httpResponse.data}}`}
+                  </FieldDescription>
+                  {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+                </Field>
+              )}
+            />
+
             <Controller
               name="method"
               control={form.control}

--- a/src/components/custom/node-http.tsx
+++ b/src/components/custom/node-http.tsx
@@ -5,6 +5,7 @@ import { BaseExecutionNode } from "./base-execution-node";
 import { type HttpRequestFormType, HttpTriggerDialog } from "./http-trigger-dialog";
 
 type HttpRequestNodeData = {
+  variableName?: string;
   endpoint?: string;
   method?: "GET" | "POST" | "PUT" | "DELETE";
   body?: string;

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -14,7 +14,6 @@ export const executeWorkflow = inngest.createFunction(
   { event: "workflows/execute.workflow" },
   async ({ event, step }) => {
     const workflowId = event.data.workflowId;
-    await step.sleep("wait", "10s");
     const sortedNodes = await step.run("prepare-workflow", async () => {
       const workflow = await db.query.workflow.findFirst({
         where: and(eq(workflowTable.id, parseInt(workflowId, 10))),

--- a/src/modules/workflows/triggers/http-trigger/executor.ts
+++ b/src/modules/workflows/triggers/http-trigger/executor.ts
@@ -1,8 +1,9 @@
 import { NonRetriableError } from "inngest";
-import type { NodeExecutor } from "../../lib/types";
 import ky, { Options as kyOption } from "ky";
+import type { NodeExecutor } from "../../lib/types";
 
 type HttpRequestData = {
+  variableName: string;
   method: "GET" | "POST" | "PUT" | "DELETE";
   endpoint?: string;
   body?: string;
@@ -18,6 +19,10 @@ export const httpTriggerExecutor: NodeExecutor<HttpRequestData> = async ({
     throw new NonRetriableError("HTTP Request node: no endpoint configured");
   }
 
+  if (!data.variableName) {
+    throw new NonRetriableError("HTTP Request node: no variable name configured");
+  }
+
   const endpoint = data.endpoint;
   const method = data.method || "GET";
   const body = data.body;
@@ -27,6 +32,9 @@ export const httpTriggerExecutor: NodeExecutor<HttpRequestData> = async ({
 
     if (["POST", "PUT", "DELETE"].includes(method)) {
       options.body = body;
+      options.headers = {
+        "Content-Type": "application/json",
+      };
     }
 
     const response = await ky(endpoint, options);
@@ -38,7 +46,7 @@ export const httpTriggerExecutor: NodeExecutor<HttpRequestData> = async ({
 
     return {
       ...context,
-      httpResponse: {
+      [data.variableName]: {
         status: response.status,
         statusText: response.statusText,
         body: responseData,


### PR DESCRIPTION
- Add a variable name field to the HTTP request dialog and node. - Use the variable name to store the HTTP response data in the execution context. - Validate the variable name to ensure it starts with a letter or underscore and contains only letters, numbers, and underscores. - Set Content-Type header to application/json for POST, PUT, and DELETE requests.