### PR TITLE
feat: Add Handlebars and use it for HTTP requests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
         "drizzle-orm": "^0.44.7",
         "embla-carousel-react": "^8.6.0",
         "global": "^4.4.0",
+        "handlebars": "^4.7.8",
         "inngest": "^3.44.5",
         "inngest-cli": "^1.13.2",
         "input-otp": "^1.4.2",
@@ -944,6 +945,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
@@ -1032,6 +1035,8 @@
 
     "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
     "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
 
     "minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
@@ -1045,6 +1050,8 @@
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "nanostores": ["nanostores@1.0.1", "", {}, "sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "next": ["next@16.0.1", "", { "dependencies": { "@next/env": "16.0.1", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.0.1", "@next/swc-darwin-x64": "16.0.1", "@next/swc-linux-arm64-gnu": "16.0.1", "@next/swc-linux-arm64-musl": "16.0.1", "@next/swc-linux-x64-gnu": "16.0.1", "@next/swc-linux-x64-musl": "16.0.1", "@next/swc-win32-arm64-msvc": "16.0.1", "@next/swc-win32-x64-msvc": "16.0.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-e9RLSssZwd35p7/vOa+hoDFggUZIUbZhIUSLZuETCwrCVvxOs87NamoUzT+vbcNAL8Ld9GobBnWOA6SbV/arOw=="],
 
@@ -1210,6 +1217,8 @@
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -1229,6 +1238,8 @@
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "drizzle-orm": "^0.44.7",
     "embla-carousel-react": "^8.6.0",
     "global": "^4.4.0",
+    "handlebars": "^4.7.8",
     "inngest": "^3.44.5",
     "inngest-cli": "^1.13.2",
     "input-otp": "^1.4.2",

--- a/src/components/custom/http-trigger-dialog.tsx
+++ b/src/components/custom/http-trigger-dialog.tsx
@@ -75,9 +75,9 @@ export const HttpTriggerDialog = ({
   const watchVariableName = form.watch("variableName") || "myApiCall";
   const showBodyField = form.watch("method") === "POST";
   const bodyPlaceholder = `{
-    "userId": "{{httpResponse.data.id}}",
-    "name": "{{httpResponse.data.name}}",
-    "items": "{{httpResponse.data.items}}"
+    "userId": "{{prev-node.httpResponse.data.id}}",
+    "name": "{{prev-node.httpResponse.data.name}}",
+    "items": "{{prev-node.httpResponse.data.items}}"
 }`;
 
   return (
@@ -145,7 +145,7 @@ export const HttpTriggerDialog = ({
                   <FieldLabel htmlFor="endpoint">Endpoint URL</FieldLabel>
                   <Input
                     id="endpoint"
-                    placeholder="https://api.example.com/users/{{httpResponse.data.id}}"
+                    placeholder="https://api.example.com/users/{{prev-node.httpResponse.data.id}}"
                     {...field}
                   />
                   <FieldDescription>

--- a/src/modules/workflows/triggers/http-trigger/executor.ts
+++ b/src/modules/workflows/triggers/http-trigger/executor.ts
@@ -1,3 +1,4 @@
+import HandleBars from "handlebars";
 import { NonRetriableError } from "inngest";
 import ky, { Options as kyOption } from "ky";
 import type { NodeExecutor } from "../../lib/types";
@@ -5,13 +6,23 @@ import type { NodeExecutor } from "../../lib/types";
 type HttpRequestData = {
   variableName: string;
   method: "GET" | "POST" | "PUT" | "DELETE";
-  endpoint?: string;
+  endpoint: string;
   body?: string;
 };
 
+HandleBars.registerHelper("json", (context) => {
+  try {
+    const jsonString = JSON.stringify(context, null, 2);
+    const safeString = new HandleBars.SafeString(jsonString);
+    return safeString;
+  } catch (error) {
+    console.error(error);
+    throw new NonRetriableError("HTTP Request node: error parsing JSON");
+  }
+});
+
 export const httpTriggerExecutor: NodeExecutor<HttpRequestData> = async ({
   data,
-  nodeId,
   context,
   step,
 }) => {
@@ -23,15 +34,28 @@ export const httpTriggerExecutor: NodeExecutor<HttpRequestData> = async ({
     throw new NonRetriableError("HTTP Request node: no variable name configured");
   }
 
-  const endpoint = data.endpoint;
-  const method = data.method || "GET";
-  const body = data.body;
+  if (!data.method) {
+    throw new NonRetriableError("HTTP Request node: no method configured");
+  }
 
+  let endpoint: string;
+  try {
+    const compiledEndpoint = HandleBars.compile(data.endpoint)(context);
+    if (!compiledEndpoint || typeof compiledEndpoint !== "string") {
+      throw new NonRetriableError("Endpoint template must resolve to a non-empty string");
+    }
+    endpoint = compiledEndpoint;
+  } catch (error) {
+    console.error(error);
+    throw new NonRetriableError("HTTP Request node: error compiling endpoint");
+  }
+
+  const method = data.method || "GET";
   const result = await step.run("http-request", async () => {
     const options: kyOption = { method };
 
     if (["POST", "PUT", "DELETE"].includes(method)) {
-      options.body = body;
+      options.body = HandleBars.compile(data.body || "{}")(context);
       options.headers = {
         "Content-Type": "application/json",
       };
@@ -44,13 +68,17 @@ export const httpTriggerExecutor: NodeExecutor<HttpRequestData> = async ({
       ? await response.json()
       : await response.text();
 
-    return {
-      ...context,
-      [data.variableName]: {
+    const responsePayload = {
+      httpResponse: {
         status: response.status,
         statusText: response.statusText,
-        body: responseData,
+        data: responseData,
       },
+    };
+
+    return {
+      ...context,
+      [data.variableName]: responsePayload,
     };
   });
 


### PR DESCRIPTION
This commit adds the Handlebars library to the project and uses it to compile the endpoint and body of HTTP requests. This allows users to use dynamic values in their HTTP requests, such as values from previous steps or the trigger payload.

The commit also updates the HTTP trigger dialog to use `{{prev-node.httpResponse.data.id}}` instead of `{{httpResponse.data.id}}` to access data from the previous step.

Finally, the commit adds a helper function to JSON stringify the HTTP response body for debugging purposes.